### PR TITLE
Add hardcoded nesting rules

### DIFF
--- a/lib/compat/wordpress-6.1/block-editor-settings.php
+++ b/lib/compat/wordpress-6.1/block-editor-settings.php
@@ -168,6 +168,19 @@ function gutenberg_get_block_editor_settings( $settings ) {
 			);
 	}
 
+	$settings['__experimentalFeatures']['blocks']['core/media-text']['core/heading']['color']['palette']['theme'] = [
+		[
+			'slug' => 'layer-accent-blue',
+			'color' => 'var(--wp--custom--layer--accent--blue)',
+			'name' => 'blue accent',
+		],
+		[
+			'slug' => 'layer-accent-orange',
+			'color' => 'var(--wp--custom--layer--accent--orange)',
+			'name' => 'orange accent',
+		],
+	];
+
 	$settings['localAutosaveInterval'] = 15;
 	$settings['disableLayoutStyles']   = current_theme_supports( 'disable-layout-styles' );
 

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, set } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -159,24 +159,6 @@ export default function useSetting( path ) {
 
 			// 2. Fall back to the settings from the block editor store (__experimentalFeatures).
 			const settings = select( blockEditorStore ).getSettings();
-
-			// Mock settings in store
-			set(
-				settings,
-				`__experimentalFeatures.blocks.core/media-text.core/heading.color.palette.theme`,
-				[
-					{
-						slug: 'layer-accent-blue',
-						color: 'var(--wp--custom--layer--accent--blue)',
-						name: 'blue accent',
-					},
-					{
-						slug: 'layer-accent-orange',
-						color: 'var(--wp--custom--layer--accent--orange)',
-						name: 'orange accent',
-					},
-				]
-			);
 
 			// 2.1 Check for nested parent block settings
 			if ( result === undefined ) {


### PR DESCRIPTION
## What?

This makes changes to the `useSetting()` JS hook to allow pulling settings from nested block settings in `theme.json`. These nested settings are currently hardcoded in `gutenberg_get_block_editor_settings()`. Future work will expand `theme.json` parsing to allow for governance rules in JSON that look something like this:

```json
"settings": {
	"blocks": {
		"core/heading": {
			"color": {
				"text": true,
				"palette": [
					{
						"slug": "text",
						"color": "var(--wp--custom--text--secondary)",
						"name": "text"
					},
					{
						"slug": "layer-accent-blue",
						"color": "var(--wp--custom--layer--accent--blue)",
						"name": "blue accent"
					}
				]
			}
		},
		"core/media-text": {
			"core/heading": {
				"color": {
					"palette": [
						{
							"slug": "layer-accent-blue",
							"color": "var(--wp--custom--layer--accent--blue)",
							"name": "blue accent"
						},
						{
							"slug": "layer-accent-orange",
							"color": "var(--wp--custom--layer--accent--orange)",
							"name": "orange accent"
						}
					]
				}
			}
		}
	}
}
```

For now, this structure is being hardcoded in PHP.

## Why?

This is a first step in allowing nested governance settings in `theme.json`.

## How?

This expands the `useSetting()` hook to loop run through parent blocks to check for nested child block settings. Contrary to prior implementation using a plugin, this no longer uses the `__experimentalSettings` property/hook. This property is related to `block.json` parsing for individual block development, but it's not connected to settings used in `theme.json`. Instead the code uses the settings from the `blockEditorStore` / `theme.json`.

The nesting code currently works like this:

1. In step 2 of `useSetting` (the `blockEditorStore` / `theme.json` related part), loop through the parent blocks of the current block.
2. If a parent block has an inner section that matches the current block's name, use these settings instead of those defined on the current block.

This works okay for a POC, but there are a few issues that need to be addressed:

- Can only handle one layer of nesting. For example, a rule in `blocks → core/media-text → core/heading` will work to override `core/heading` rules when in `core/media-text`, but a deeper nested `blocks → core/group → core/media-text → core/heading` will not apply to the heading. This needs to be expanded to allow for multi-layered rules.
- There's no specificity rules for determining the winner if nested block settings are defined in multiple places. Ideally this should work with CSS-like specificity where deeper nested settings ("selectors") override shallower nested settings.
- Palette colors that are only defined in a nested block and not a root block do not apply correctly, because CSS palette colors are only generated for the base class. This is because `theme.json` parsing is not yet implemented, but it should be addressed in that work.
- No tests.

## Testing Instructions

This version of the Gutenberg plugin was tested with a theme enabled with a `theme.json` color palette set for `core/heading.`

## Screenshots

Here's a quick GIF showing a regular heading and nested heading with different palette settings:

![2022-08-24 09 57 47](https://user-images.githubusercontent.com/17870752/186301628-70115302-3cfd-4637-86d0-5eeab497db34.gif)