### PR TITLE
Add `useSetting()` hook tests

### DIFF
--- a/lib/compat/wordpress-6.1/block-editor-settings.php
+++ b/lib/compat/wordpress-6.1/block-editor-settings.php
@@ -168,18 +168,22 @@ function gutenberg_get_block_editor_settings( $settings ) {
 			);
 	}
 
-	$settings['__experimentalFeatures']['blocks']['core/media-text']['core/heading']['color']['palette']['theme'] = [
-		[
-			'slug' => 'layer-accent-blue',
-			'color' => 'var(--wp--custom--layer--accent--blue)',
-			'name' => 'blue accent',
-		],
-		[
-			'slug' => 'layer-accent-orange',
-			'color' => 'var(--wp--custom--layer--accent--orange)',
-			'name' => 'orange accent',
-		],
-	];
+	$settings['__experimentalFeatures']['blocks']['core/media-text']['core/heading']['color'] = array(
+		'palette' => array(
+			'theme' => array(
+				array(
+					'slug'  => 'layer-accent-blue',
+					'color' => 'var(--wp--custom--layer--accent--blue)',
+					'name'  => 'blue accent',
+				),
+				array(
+					'slug'  => 'layer-accent-orange',
+					'color' => 'var(--wp--custom--layer--accent--orange)',
+					'name'  => 'orange accent',
+				),
+			),
+		),
+	);
 
 	$settings['localAutosaveInterval'] = 15;
 	$settings['disableLayoutStyles']   = current_theme_supports( 'disable-layout-styles' );

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -166,7 +166,6 @@ export default function useSetting( path ) {
 				// Needs some work:
 				//   - Can only handle one layer of nesting
 				//   - No CSS-like specificity rules for determining winner if a block is nested in multiple places
-				//   - No tests
 
 				blockParentIds.forEach( ( blockParentId ) => {
 					const parentBlockName =

--- a/packages/block-editor/src/components/use-setting/test/index.js
+++ b/packages/block-editor/src/components/use-setting/test/index.js
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import { cloneDeep } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useSetting from '..';
+import * as BlockEditContext from '../../block-edit/context';
+
+describe( 'useSetting', () => {
+	beforeEach( () => {
+		selectMock = cloneDeep( selectMockDefaults );
+		mockCurrentBlockContext( {} );
+	} );
+
+	it( 'uses theme setting', () => {
+		mockSettings( {
+			color: {
+				text: false,
+			},
+		} );
+
+		expect( useSetting( 'color.text' ) ).toBe( false );
+	} );
+
+	it( 'uses block-specific setting', () => {
+		mockSettings( {
+			color: {
+				text: false,
+			},
+			blocks: {
+				'core/test-block': {
+					color: {
+						text: true,
+					},
+				},
+			},
+		} );
+
+		mockCurrentBlockContext( {
+			name: 'core/test-block',
+		} );
+
+		expect( useSetting( 'color.text' ) ).toBe( true );
+	} );
+
+	it( 'does not use block-specific setting from another block', () => {
+		mockSettings( {
+			color: {
+				text: false,
+			},
+			blocks: {
+				'core/test-block': {
+					color: {
+						text: true,
+					},
+				},
+			},
+		} );
+
+		mockCurrentBlockContext( {
+			name: 'core/unrelated-block',
+		} );
+
+		expect( useSetting( 'color.text' ) ).toBe( false );
+	} );
+
+	it( 'uses 1-layer deep nested block setting', () => {
+		mockSettings( {
+			color: {
+				text: false,
+			},
+			blocks: {
+				'core/parent-block': {
+					color: {
+						text: false,
+					},
+					'core/child-block': {
+						color: {
+							text: true,
+						},
+					},
+				},
+			},
+		} );
+
+		mockCurrentBlockContext( {
+			name: 'core/child-block',
+			clientId: 'client-id-child-block',
+		} );
+
+		mockBlockParent( 'client-id-child-block', {
+			name: 'core/parent-block',
+			clientId: 'client-id-parent-block',
+		} );
+
+		expect( useSetting( 'color.text' ) ).toBe( true );
+	} );
+} );
+
+// useSelect() mock functions for blockEditorStore
+jest.mock( '@wordpress/data/src/components/use-select' );
+
+const selectMockDefaults = {
+	getSettings: () => ( {} ),
+	getBlockParents: () => [],
+	getBlockName: () => '',
+};
+
+let selectMock = {};
+
+useSelect.mockImplementation( ( callback ) => callback( () => selectMock ) );
+
+const mockSettings = ( settings ) => {
+	selectMock.getSettings = () => ( {
+		__experimentalFeatures: settings,
+	} );
+};
+
+const mockBlockParent = (
+	childClientId,
+	{ clientId: parentBlockClientId, name: parentBlockName }
+) => {
+	const previousGetBlockParents = selectMock.getBlockParents;
+
+	selectMock.getBlockParents = ( clientId ) => {
+		if ( clientId === childClientId ) {
+			return [ parentBlockClientId ];
+		}
+
+		return previousGetBlockParents( clientId );
+	};
+
+	mockBlockName( parentBlockClientId, parentBlockName );
+};
+
+const mockBlockName = ( blockClientId, blockName ) => {
+	const previousGetBlockName = selectMock.getBlockName;
+
+	selectMock.getBlockName = ( clientId ) => {
+		if ( clientId === blockClientId ) {
+			return blockName;
+		}
+
+		return previousGetBlockName( clientId );
+	};
+};
+
+const mockCurrentBlockContext = (
+	blockContext = { name: '', isSelected: false }
+) => {
+	jest.spyOn( BlockEditContext, 'useBlockEditContext' ).mockReturnValue(
+		blockContext
+	);
+};


### PR DESCRIPTION
## What?

This adds some tests for `useSetting()`. Despite having some tricky logic, this hook previously had no associated tests.

## Why?

As nesting/specificity logic gets more complicated, manual testing of `useSetting()` will get more difficult. I wanted a set of baseline tests to ensure that I'm not causing regressions during development, and a way to easily test more complex settings setups without manually changing `theme.json`.

## How?

The mocking setup for tests is a little complicated. `useSetting` relies on a few internal hooks:

- `useBlockEditContext()` used to get the current relevant block
- `useSelect` is used on the `blockEditorStore` in a few contexts:
    - `select( blockEditorStore ).getSettings()`: Return the result of parsing/merging `theme.json` settings.
    - `select( blockEditorStore ).getBlockParents( clientId )`: For a block ID, return the parent IDs of the block
    - `select( blockEditorStore ).getBlockName( clientId )`: For a block ID, return the block's name (e.g. `core/heading`)

For complicated tests, all of these must be overridden to work properly. The code has a set of mocking functions that should simplify things a bit with using these functions:

- `mockSettings( settings )`: Adds settings that would normally be pulled from `theme.json → settings`.
- `mockCurrentBlockContext( currentBlock )`: This marks the "cursor" of the active block. Settings are pulled from the current block context, so any settings tests also need to define which block is being tested with this mock.
- `mockBlockParent( childId, parentBlock )`: Can be used to define a basic tree structure for testing nesting logic.

There's still work that can be done to make the tests less dependent on `useSetting`'s structure and the Jest mocking could be scoped down, but these should be better than the current setup with no tests.

## Testing Instructions

These tests can be run with the entire test suite with `npm run test:unit`, or more specifically via:

```sh
$ npx wp-scripts test-unit-js --config test/unit/jest.config.js packages/block-editor/src/components/use-setting/test/index.js

 PASS  packages/block-editor/src/components/use-setting/test/index.js
  useSetting
    ✓ uses theme setting (3 ms)
    ✓ uses block-specific setting (1 ms)
    ✓ does not use block-specific setting from another block
    ✓ uses 1-layer deep nested block setting

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        3.411 s
Ran all test suites matching /packages\/block-editor\/src\/components\/use-setting\/test\/index.js/i.
```
