### PR TITLE
Add new e2e test for nested block settings

### DIFF
--- a/test/e2e/specs/editor/blocks/nestedBlocks.spec.js
+++ b/test/e2e/specs/editor/blocks/nestedBlocks.spec.js
@@ -16,7 +16,7 @@ test.describe( 'Nested Block Settings', () => {
 		await admin.createNewPost();
 	} );
 
-	test( 'should output a quote with a heading, media-text with another heading inside', async ( {
+	test( 'should output a quote with a heading, that only allows red coloured text', async ( {
 		editor,
 		page,
 	} ) => {

--- a/test/e2e/specs/editor/blocks/nestedBlocks.spec.js
+++ b/test/e2e/specs/editor/blocks/nestedBlocks.spec.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Nested Block Settings', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test( 'should output a quote with a heading, media-text with another heading inside', async ( {
+		editor,
+	} ) => {
+		// Loading it this way forces the nested block settings to be loaded, which in itself technically tests the new nested block settings code.
+		await editor.insertBlock( {
+			name: 'core/quote',
+			innerBlocks: [
+				{
+					name: 'core/heading',
+				},
+				{
+					name: 'core/media-text',
+					innerBlocks: [
+						{
+							name: 'core/heading',
+						},
+					],
+				},
+			],
+		} );
+
+		const editedPostContent = await editor.getEditedPostContent();
+		expect( editedPostContent ).toBe(
+			`<!-- wp:quote -->
+<blockquote class="wp-block-quote"><!-- wp:heading -->
+<h2></h2>
+<!-- /wp:heading -->
+
+<!-- wp:media-text -->
+<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:heading -->
+<h2></h2>
+<!-- /wp:heading --></div></div>
+<!-- /wp:media-text --></blockquote>
+<!-- /wp:quote -->`
+		);
+
+		//To-Do: Verify the correct style is shown for the above set of blocks.
+	} );
+} );

--- a/test/e2e/specs/editor/blocks/nestedBlocks.spec.js
+++ b/test/e2e/specs/editor/blocks/nestedBlocks.spec.js
@@ -18,6 +18,7 @@ test.describe( 'Nested Block Settings', () => {
 
 	test( 'should output a quote with a heading, media-text with another heading inside', async ( {
 		editor,
+		page,
 	} ) => {
 		// Loading it this way forces the nested block settings to be loaded, which in itself technically tests the new nested block settings code.
 		await editor.insertBlock( {
@@ -26,32 +27,30 @@ test.describe( 'Nested Block Settings', () => {
 				{
 					name: 'core/heading',
 				},
-				{
-					name: 'core/media-text',
-					innerBlocks: [
-						{
-							name: 'core/heading',
-						},
-					],
-				},
 			],
 		} );
+
+		await page.click( '[data-type="core/heading"]' );
+
+		await page.keyboard.type( 'hello' );
+
+		await page.click( 'role=button[name="Text"i]' );
+
+		await expect(
+			page.locator( "[aria-label='Color: Red']" )
+		).toBeVisible();
+
+		await expect(
+			page.locator( "[aria-label='Color: Light']" )
+		).toBeHidden();
 
 		const editedPostContent = await editor.getEditedPostContent();
 		expect( editedPostContent ).toBe(
 			`<!-- wp:quote -->
 <blockquote class="wp-block-quote"><!-- wp:heading -->
-<h2></h2>
-<!-- /wp:heading -->
-
-<!-- wp:media-text -->
-<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:heading -->
-<h2></h2>
-<!-- /wp:heading --></div></div>
-<!-- /wp:media-text --></blockquote>
+<h2>hello</h2>
+<!-- /wp:heading --></blockquote>
 <!-- /wp:quote -->`
 		);
-
-		//To-Do: Verify the correct style is shown for the above set of blocks.
 	} );
 } );

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -5,14 +5,14 @@
 		"color": {
 			"palette": [
 				{
+					"slug": "red",
+					"name": "Red",
+					"color": "#ce0808"
+				},
+				{
 					"slug": "light",
 					"name": "Light",
 					"color": "#f5f7f9"
-				},
-				{
-					"slug": "dark",
-					"name": "Dark",
-					"color": "#000"
 				}
 			]
 		},
@@ -27,31 +27,11 @@
 						"text": true,
 						"palette": [
 							{
-								"slug": "dark",
-								"name": "Dark",
-								"color": "#000"
+								"slug": "red",
+								"name": "Red",
+								"color": "#ce0808"
 							}
 						]
-					},
-					"typography": {
-						"fontWeight": "500"
-					}
-				},
-				"core/media-text": {
-					"core/heading": {
-						"color": {
-							"text": true,
-							"palette": [
-								{
-									"slug": "light",
-									"name": "Light",
-									"color": "#f5f7f9"
-								}
-							]
-						},
-						"typography": {
-							"fontWeight": "700"
-						}
 					}
 				}
 			}

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -2,9 +2,59 @@
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,
+		"color": {
+			"palette": [
+				{
+					"slug": "light",
+					"name": "Light",
+					"color": "#f5f7f9"
+				},
+				{
+					"slug": "dark",
+					"name": "Dark",
+					"color": "#000"
+				}
+			]
+		},
 		"layout": {
 			"contentSize": "840px",
 			"wideSize": "1100px"
+		},
+		"blocks": {
+			"core/quote": {
+				"core/heading": {
+					"color": {
+						"text": true,
+						"palette": [
+							{
+								"slug": "dark",
+								"name": "Dark",
+								"color": "#000"
+							}
+						]
+					},
+					"typography": {
+						"fontWeight": "500"
+					}
+				},
+				"core/media-text": {
+					"core/heading": {
+						"color": {
+							"text": true,
+							"palette": [
+								{
+									"slug": "light",
+									"name": "Light",
+									"color": "#f5f7f9"
+								}
+							]
+						},
+						"typography": {
+							"fontWeight": "700"
+						}
+					}
+				}
+			}
 		}
 	},
 	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]


### PR DESCRIPTION
This is meant to add a new test that essentially tests the nested block settings code, by:

- Modify the theme.json to only allow a red colour to be set for a heading nested inside a quote block
- Creating a post with that exact setup
- Verifying post content lines up with that setup
- Verifying that the style of the heading can only be set to read